### PR TITLE
Revamp status HUD and UI interactions

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -37,15 +37,7 @@
     </div>
 </div>
 
-    <div id="player-info">
-        <p id="betting-status">
-            Balance: <span id="balance-images"></span> | Bet: $0
-        </p>
-        <p id="rent-status">Rent Due: $0 in 0 rolls</p>
-    </div>
-
-
-<button id="showCombinationsButton">Show Combinations</button>
+    <button id="showCombinationsButton" class="chip-button">Show Combinations</button>
             <!-- Hustler Info -->
             <div id="hustler-info">
                 <p id="multiplier-display">Multiplier: 1x</p> <!-- New Multiplier Display -->
@@ -88,23 +80,41 @@
 
         <!-- Right Side -->
         <div id="right-side">
-            <div id="balance-display" style="display: flex; justify-content: center; align-items: center; margin-top: 10px;">
-                <!-- Balance images will be displayed here -->
+            <div id="status-hud">
+                <div class="status-card balance-card" id="betting-status">
+                    <div class="status-card__header">
+                        <span class="status-card__label">Balance</span>
+                        <span class="status-card__pulse" id="balance-trend">--</span>
+                    </div>
+                    <div class="status-card__value" id="balance-number">$0</div>
+                    <div class="status-card__sub">Bet: <span id="bet-amount-text">$0</span></div>
+                    <div id="balance-display" class="balance-display"></div>
+                </div>
+                <div class="status-card rent-card" id="rent-status">
+                    <div class="status-card__label">Rent Due</div>
+                    <div class="status-card__value" id="rent-amount-text">$0</div>
+                    <div class="status-card__sub">Rolls Left: <span id="rent-rolls-text">0</span></div>
+                </div>
+                <div class="status-card multiplier-card">
+                    <div class="status-card__label">Multiplier</div>
+                    <div class="status-card__value" id="multiplier-display">1.00x</div>
+                    <div class="status-card__sub" id="multiplier-details">Stack wins to power up.</div>
+                </div>
+                <div class="status-card earnings-card" id="earnings-card">
+                    <div class="status-card__label">Earnings / Sec</div>
+                    <div class="status-card__value">$<span id="earnings-per-second">0.00</span></div>
+                    <div class="status-card__sub" id="earnings-trend">Awaiting action…</div>
+                </div>
             </div>
-            <div id="earnings-counter" style="text-align: center; font-size: 18px; margin-top: 5px;">
-                Earnings per Second: $<span id="earnings-per-second">0.00</span>
-            </div>
-            
-            
 
             <div id="controls">
                 <img id="rollButton" src="/images/Button_RollDice.gif" alt="Roll Dice" class="button-image">
-                <input type="number" id="betAmount" placeholder="Enter Bet Amount" min="1">
+                <input type="number" id="betAmount" class="pill-input" placeholder="Enter Bet Amount" min="1">
                 <img id="betButton" src="/images/Button_PlaceBet.gif" alt="Place Bet" class="button-image">
                 <img id="bet25Button" src="/images/Button_Bet25.gif" alt="Bet 25%" class="button-image">
                 <img id="bet50Button" src="/images/Button_Bet50.gif" alt="Bet 50%" class="button-image">
                 <img id="bet100Button" src="/images/Button_Bet100.gif" alt="Bet 100%" class="button-image">
-                <button id="quitButton" class="small-button">Quit Game</button>
+                <button id="quitButton" class="chip-button danger">Quit Game</button>
             </div>
 
             <div id="dice-container">
@@ -140,8 +150,22 @@
         </div>
         <img id="eth-bet-button" src="/images/Button_PlaceBet.gif" alt="Place Bet (ETH)" class="button-image crypto-bet-button">
     </div>
-    
-    
+
+    <div id="fortune-area">
+        <div id="fortune-cookie-section">
+            <img id="cookie-buy" src="/images/cookie_Buy.png" alt="Buy Fortune Cookie">
+            <button id="buy-cookie-button" class="chip-button fortune">
+                <img src="/images/ETH_Logo.png" alt="ETH Logo">
+                Buy ($1 ETH)
+            </button>
+        </div>
+        <div id="fortune-collection">
+            <h3>My Fortune Cookies</h3>
+            <p>Collected: <span id="cookie-count">0</span>/25</p>
+            <div id="my-fortunes" class="fortune-collection__grid"></div>
+        </div>
+    </div>
+
     <div id="shop-container">
         <h3>Shop</h3>
         <div id="hustler-list">
@@ -186,15 +210,6 @@
     </div>
 </div>
 
-<!-- Fortune Cookie Section -->
-<div id="fortune-cookie-section">
-    <img id="cookie-buy" src="/images/cookie_Buy.png" alt="Buy Fortune Cookie">
-    <button id="buy-cookie-button">
-        <img src="/images/ETH_Logo.png" alt="ETH Logo">
-        Buy ($1 ETH)
-    </button>
-</div>
-
 <div id="fortune-display" style="display: none;">
     <img id="cookie-open" src="/images/cookie_Open.png" alt="Open Fortune Cookie">
     <div id="fortune-text"></div>
@@ -214,13 +229,6 @@
         <button id="send-message">Send</button>
     </div>
 </div>
-
-<div id="fortune-collection">
-    <h3>My Fortune Cookies</h3>
-    <p>Collected: <span id="cookie-count">0</span>/25</p>
-    <div id="collected-cookies"></div> <!-- Updated to use a div for flex display -->
-</div>
-
 
 <script src="/socket.io/socket.io.js"></script> <!-- Load Socket.IO -->
 <script src="/socket-init.js"></script> <!-- Initialize Socket -->

--- a/public/index.html
+++ b/public/index.html
@@ -91,24 +91,7 @@
 </div>
 
 
-<!-- Chat -->
-<div id="chat-container" class="chat-minimized">
-    <div id="chat-header">
-        <span>Chat</span>
-        <button id="toggle-chat" onclick="console.log('Chat button pressed')">☰</button>
-    </div>
-    <div id="chat-body">
-        <div id="player-list">
-            <strong>Online Players:</strong>
-            <ul id="player-names"></ul>
-        </div>
-        <div id="message-list"></div>
-    </div>
-    <div id="chat-footer">
-        <input id="message-input" type="text" placeholder="Type your message..." />
-        <button id="send-message">Send</button>
-    </div>
-</div>
+<!-- Chat container is now handled by the in-game overlay -->
 
 
 <div id="lottery-widget">
@@ -162,8 +145,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const showMainMenu = () => {
         introContainer.style.display = 'none';
         mainMenu.style.display = 'flex';
-        chatContainer.classList.remove('chat-minimized'); // Ensure chat is visible
-        chatContainer.style.display = 'block'; // Explicitly make chat visible
+        if (chatContainer) {
+            chatContainer.classList.remove('chat-minimized');
+            chatContainer.style.display = 'block';
+        }
     };
 
     const introSFX = new Audio('sounds/IntroVideoSFX_0.ogg');

--- a/public/style.css
+++ b/public/style.css
@@ -120,6 +120,221 @@ h1 {
     margin: 8px;
 }
 
+#status-hud {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-bottom: 28px;
+    padding: 0 8px;
+}
+
+.status-card {
+    position: relative;
+    padding: 18px 20px 24px;
+    border-radius: 18px;
+    background: linear-gradient(160deg, rgba(30, 30, 45, 0.95) 0%, rgba(12, 12, 18, 0.95) 55%, rgba(4, 4, 8, 0.98) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 16px 28px rgba(0, 0, 0, 0.42);
+    overflow: hidden;
+    transition: transform 0.25s ease, border-color 0.3s ease;
+}
+
+.status-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 45%);
+    opacity: 0.4;
+}
+
+.status-card__label {
+    font-size: 0.74rem;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: rgba(186, 199, 255, 0.85);
+}
+
+.status-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.status-card__value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #fdf6ff;
+    text-shadow: 0 8px 16px rgba(110, 180, 255, 0.45);
+    line-height: 1.1;
+}
+
+.status-card__sub {
+    margin-top: 6px;
+    font-size: 0.82rem;
+    color: rgba(212, 225, 255, 0.75);
+    letter-spacing: 0.04em;
+}
+
+.status-card__pulse {
+    font-size: 0.75rem;
+    color: rgba(144, 178, 255, 0.8);
+    letter-spacing: 0.15em;
+}
+
+.balance-card {
+    background: linear-gradient(150deg, rgba(45, 47, 78, 0.95) 0%, rgba(15, 16, 35, 0.97) 60%, rgba(5, 5, 18, 0.98) 100%);
+    border-color: rgba(121, 162, 255, 0.35);
+}
+
+.rent-card {
+    border-color: rgba(255, 180, 95, 0.35);
+}
+
+.multiplier-card {
+    border-color: rgba(161, 110, 255, 0.4);
+}
+
+.earnings-card {
+    border-color: rgba(106, 255, 210, 0.32);
+}
+
+.balance-display {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    margin-top: 12px;
+}
+
+.balance-display img {
+    width: 36px;
+    height: auto;
+    filter: drop-shadow(0 8px 10px rgba(98, 160, 255, 0.25));
+}
+
+.combination-summary {
+    margin: 10px 0 18px;
+    font-size: 0.9rem;
+    color: rgba(214, 225, 255, 0.7);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.chip-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 22px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background-image: none;
+    background: radial-gradient(120% 120% at 50% 10%, rgba(55, 55, 75, 0.9) 0%, rgba(12, 12, 20, 0.96) 58%, rgba(5, 5, 9, 0.98) 100%);
+    color: #f4f6ff;
+    font-size: 0.86rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.chip-button img {
+    width: 22px;
+    height: 22px;
+}
+
+.chip-button:hover {
+    transform: translateY(-3px);
+    border-color: rgba(255, 196, 87, 0.5);
+    box-shadow: 0 16px 24px rgba(255, 187, 80, 0.28);
+}
+
+.chip-button.danger {
+    background: linear-gradient(150deg, rgba(255, 92, 92, 0.92) 0%, rgba(150, 20, 20, 0.92) 65%, rgba(80, 10, 10, 0.95) 100%);
+    border-color: rgba(255, 128, 128, 0.45);
+}
+
+.chip-button.danger:hover {
+    box-shadow: 0 16px 24px rgba(255, 90, 90, 0.45);
+}
+
+.chip-button.fortune {
+    background: linear-gradient(160deg, rgba(255, 216, 128, 0.92) 0%, rgba(237, 134, 255, 0.92) 60%, rgba(125, 90, 255, 0.96) 100%);
+    color: #1b1230;
+    border-color: rgba(255, 255, 255, 0.4);
+    font-weight: 700;
+}
+
+.chip-button.fortune:hover {
+    box-shadow: 0 18px 26px rgba(205, 130, 255, 0.45);
+}
+
+.pill-input {
+    border: none;
+    border-radius: 999px;
+    padding: 10px 18px;
+    background-image: none;
+    background: radial-gradient(120% 120% at 50% 10%, rgba(35, 35, 60, 0.9) 0%, rgba(14, 14, 24, 0.95) 55%, rgba(6, 6, 8, 0.98) 100%);
+    border: 1px solid rgba(132, 158, 255, 0.32);
+    color: #f1f4ff;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    min-width: 160px;
+    text-align: center;
+}
+
+.pill-input::placeholder {
+    color: rgba(181, 199, 255, 0.55);
+    font-weight: 500;
+}
+
+.pill-input:focus {
+    outline: none;
+    border-color: rgba(102, 186, 255, 0.8);
+    box-shadow: 0 0 0 3px rgba(84, 174, 255, 0.28);
+}
+
+.balance-card.balance-up,
+.balance-card.balance-down {
+    animation-duration: 540ms;
+    animation-timing-function: ease-out;
+}
+
+.balance-card.balance-up {
+    animation-name: balanceRise;
+    border-color: rgba(108, 255, 189, 0.55);
+}
+
+.balance-card.balance-down {
+    animation-name: balanceDip;
+    border-color: rgba(255, 140, 140, 0.55);
+}
+
+@keyframes balanceRise {
+    0% { transform: translateY(0) scale(1); }
+    40% { transform: translateY(-6px) scale(1.04); }
+    100% { transform: translateY(0) scale(1); }
+}
+
+@keyframes balanceDip {
+    0% { transform: translateY(0) scale(1); }
+    45% { transform: translateY(6px) scale(0.96); }
+    100% { transform: translateY(0) scale(1); }
+}
+
+.earnings-card.positive {
+    border-color: rgba(111, 255, 209, 0.62);
+    box-shadow: 0 16px 28px rgba(110, 255, 209, 0.28);
+}
+
+.earnings-card.negative {
+    border-color: rgba(255, 128, 128, 0.55);
+    box-shadow: 0 16px 28px rgba(255, 110, 110, 0.25);
+}
+
 /* Item Popup Styling */
 #itemPopup {
     display: none;
@@ -1002,49 +1217,62 @@ h1 {
     max-height: 100%;
 }
 
-#balance-images {
-    display: inline-flex; /* Make images appear in a row */
-    align-items: center; /* Vertically align images */
-    gap: 2px; /* Space between digits */
+#fortune-area {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+    margin: 30px auto 10px;
+    width: min(820px, 100%);
 }
 
-.balance-digit {
-    width: 20px; /* Adjust size as needed */
-    height: 20px;
-    background-size: contain; /* Scale images to fit the container */
-    background-repeat: no-repeat; /* Prevent tiling */
-    display: inline-block;
-}
-/* Fortune Cookie Section Styling */
 #fortune-cookie-section {
-    position: absolute;
-    bottom: 10px;
-    left: 10px;
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: 20px;
+    border-radius: 20px;
+    background: radial-gradient(120% 120% at 50% 0%, rgba(255, 196, 87, 0.18) 0%, rgba(20, 20, 20, 0.88) 55%, rgba(6, 6, 6, 0.92) 100%);
+    border: 1px solid rgba(255, 170, 0, 0.25);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
 }
 
 #fortune-cookie-section img {
-    width: 50px;
+    width: 68px;
     cursor: pointer;
+    filter: drop-shadow(0 8px 12px rgba(255, 184, 67, 0.35));
 }
 
-#fortune-cookie-section button {
-    background-color: #444;
-    color: #627eeb;
-    border: none;
-    border-radius: 5px;
-    padding: 5px 10px;
-    font-size: 14px;
-    cursor: pointer;
-    margin-top: 5px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 5px;
+#fortune-collection {
+    padding: 20px;
+    border-radius: 20px;
+    background: linear-gradient(140deg, rgba(33, 33, 48, 0.85) 0%, rgba(10, 10, 14, 0.94) 60%, rgba(3, 3, 5, 0.98) 100%);
+    border: 1px solid rgba(135, 206, 255, 0.18);
+    box-shadow: 0 14px 32px rgba(10, 16, 34, 0.5);
+    text-align: center;
 }
 
-#fortune-cookie-section button:hover {
-    background-color: #285a03;
+#fortune-collection h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #8fd2ff;
+}
+
+#fortune-collection p {
+    margin: 6px 0 16px;
+    color: rgba(217, 234, 255, 0.8);
+    font-size: 0.9rem;
+}
+
+.fortune-collection__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(38px, 1fr));
+    gap: 10px;
+    justify-items: center;
+    padding: 6px;
 }
 
 #fortune-display {
@@ -1078,44 +1306,6 @@ h1 {
     list-style: none;
     padding: 0;
     margin: 0;
-}
-
-#fortune-collection li {
-    margin: 5px 0;
-}
-/* Fortune Cookie Collection Styling */
-#fortune-collection {
-    position: absolute;
-    bottom: 10px;
-    right: 10px;
-    background-color: rgba(0, 0, 0, 0.8);
-    color: white;
-    padding: 10px;
-    border-radius: 10px;
-    text-align: center;
-    width: 200px; /* Adjust size for a compact layout */
-}
-
-#collected-cookies {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
-    justify-content: center;
-    margin-top: 10px;
-}
-
-.cookie-icon {
-    position: relative;
-    width: 40px; /* Adjust size for small icons */
-    height: 40px;
-    background: url('/images/cookie_Open.png') no-repeat center center;
-    background-size: contain;
-    cursor: pointer;
-    text-align: center;
-    line-height: 40px; /* Center the number vertically */
-    font-size: 14px;
-    color: rgb(255, 0, 0);
-    font-weight: bold;
 }
 
 .cookie-icon:hover::after {
@@ -1534,23 +1724,7 @@ body {
 
 /* Button Styles */
 #showCombinationsButton {
-    background-color: #d30000; /* Green background */
-    color: #ffffff; /* White text */
-    padding: 10px 10px; /* Padding for button */
-    border: none; /* Remove border */
-    border-radius: 8px; /* Rounded corners */
-    font-size: 16px; /* Font size */
-    cursor: pointer; /* Pointer cursor on hover */
-    transition: background-color 0.3s ease, transform 0.2s ease; /* Smooth transitions */
-}
-
-#showCombinationsButton:hover {
-    background-color: #710101; /* Darker green on hover */
-    transform: scale(1.05); /* Slightly enlarge */
-}
-
-#showCombinationsButton:active {
-    transform: scale(0.95); /* Slightly shrink on click */
+    margin: 12px auto;
 }
 
 /* Modal Background Overlay */


### PR DESCRIPTION
## Summary
- replace the single player HUD with animated balance, rent, multiplier, and earnings panels tied into new stat tracking
- restyle the fortune cookie purchase and control buttons with the new chip aesthetic and relocate the fortune collection beside the store
- overhaul the combinations modal to surface tracked roll counts and remove the obsolete main menu chat container

## Testing
- npm run start *(fails: requires wallet configuration in bServer.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d507e44338832d88da30b2cc5869fd