### PR TITLE
Refine game layout and dice interactions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -242,7 +242,7 @@ async function setupSinglePlayer() {
     
     const betInput = document.getElementById('betAmount');
     const ethInput = document.getElementById('betAmountETH');
-    const ethBetButton = document.getElementById('eth-bet-button');
+    const ethActionButton = document.getElementById('eth-place-bet');
 
     setEarningsPerSecond(0);
 
@@ -346,11 +346,11 @@ async function setupSinglePlayer() {
                 : '/images/Button_PlaceBet.gif';
         }
 
-        if (ethBetButton && ethInput) {
+        if (ethActionButton && ethInput) {
             const ethValue = parseFloat(ethInput.value || '0');
-            ethBetButton.src = ethValue > 0
-                ? '/images/Button_PlaceBet_Active.gif'
-                : '/images/Button_PlaceBet.gif';
+            const hasEth = ethValue > 0;
+            ethActionButton.classList.toggle('is-disabled', !hasEth);
+            ethActionButton.disabled = !hasEth;
         }
     }
 
@@ -394,6 +394,17 @@ async function setupSinglePlayer() {
             playSound('/sounds/UI_Click1.ogg');
             setBet(balance);
         });
+
+        if (ethActionButton) {
+            ethActionButton.addEventListener('click', () => {
+                const betAmountETH = ethInput?.value;
+                if (betAmountETH && parseFloat(betAmountETH) > 0) {
+                    placeBet(betAmountETH);
+                } else {
+                    showGameMessage('Enter an ETH amount to place a bet.', 'warning');
+                }
+            });
+        }
    
 
         function setBet(input) {
@@ -544,7 +555,7 @@ async function setupSinglePlayer() {
                 refreshBetButtons();
                 updateUIAfterRoll();
 
-            });
+            }, { onFire });
         }
 
     // Attach handleRollDice to the window object
@@ -794,37 +805,6 @@ if (skipIntroButton) {
         mainMenu.style.display = 'flex';
     });
 });
-
-
-function animateDice(dice1, dice2, callback) {
-    const dice1Element = document.getElementById('dice1');
-    const dice2Element = document.getElementById('dice2');
-
-    if (!dice1Element || !dice2Element) {
-        console.error("Dice elements not found in the DOM.");
-        return;
-    }
-
-    // Set the rolling animation for both dice
-    const rollingAnimation = '/images/3dDiceRoll_1.gif';
-    dice1Element.src = rollingAnimation;
-    dice2Element.src = rollingAnimation;
-
-    // Play the rolling sound effect
-    playSound(["/sounds/DiceRoll1.ogg", "/sounds/DiceRoll2.ogg", "/sounds/DiceRoll3.ogg"], true);
-
-    // Wait for the rolling animation to finish before showing the result
-    setTimeout(() => {
-        // Set the final dice result based on whether "onFire" is active
-        dice1Element.src = `/images/${onFire ? 'DiceFire' : 'dice'}${dice1}${onFire ? '.gif' : '.gif'}`;
-        dice2Element.src = `/images/${onFire ? 'DiceFire' : 'dice'}${dice2}${onFire ? '.gif' : '.gif'}`;
-
-        // Execute the callback function after the final dice are displayed
-        if (typeof callback === 'function') {
-            callback();
-        }
-    }, 2000); // Adjust this timeout to match the duration of your rolling animation GIF
-}
 
 
     function updateUIAfterRoll() {
@@ -1339,9 +1319,10 @@ export async function placeBet(betAmountETH) {
         if (ethInputField) {
             ethInputField.value = '';
         }
-        const ethBetImage = document.getElementById('eth-bet-button');
-        if (ethBetImage) {
-            ethBetImage.src = '/images/Button_PlaceBet.gif';
+        const ethPlaceBetButton = document.getElementById('eth-place-bet');
+        if (ethPlaceBetButton) {
+            ethPlaceBetButton.classList.add('is-disabled');
+            ethPlaceBetButton.disabled = true;
         }
 
         // Simulate game outcome (for example purposes)
@@ -1373,8 +1354,6 @@ function initializeCryptoButtons() {
     const copyKrakenButton = document.getElementById('copy-kraken-address');
     const krakenAddressElement = document.getElementById('kraken-btc-address');
     const connectMetaMaskButton = document.getElementById('connect-metamask');
-    const ethBetButtonElement = document.getElementById('eth-bet-button');
-    const ethInputField = document.getElementById('betAmountETH');
 
     if (krakenAddressElement) {
         krakenAddressElement.textContent = krakenBtcAddress;
@@ -1424,16 +1403,6 @@ function initializeCryptoButtons() {
         });
     }
 
-    if (ethBetButtonElement) {
-        ethBetButtonElement.addEventListener('click', () => {
-            const betAmountETH = ethInputField?.value;
-            if (betAmountETH && parseFloat(betAmountETH) > 0) {
-                placeBet(betAmountETH);
-            } else {
-                showGameMessage('Enter an ETH amount to place a bet.', 'warning');
-            }
-        });
-    }
 }
 
  //  Refactor Wallet Restoration

--- a/public/game.html
+++ b/public/game.html
@@ -45,31 +45,35 @@
         <!-- Left Side -->
         <div id="left-side">
             <div id="status-hud">
-                <div class="status-card balance-card" id="betting-status">
-                    <div class="status-card__header">
-                        <span class="status-card__label">Balance</span>
-                        <span class="status-card__pulse" id="balance-trend">--</span>
+                <div class="status-hud__primary">
+                    <div class="status-card balance-card" id="betting-status">
+                        <div class="status-card__header">
+                            <span class="status-card__label">Balance</span>
+                            <span class="status-card__pulse" id="balance-trend">--</span>
+                        </div>
+                        <div class="status-card__value" id="balance-number">$0</div>
+                        <div class="status-card__sub">Bet: <span id="bet-amount-text">$0</span></div>
+                        <div id="balance-display" class="balance-display"></div>
+                        <div id="betting-status-note" class="status-card__note"></div>
                     </div>
-                    <div class="status-card__value" id="balance-number">$0</div>
-                    <div class="status-card__sub">Bet: <span id="bet-amount-text">$0</span></div>
-                    <div id="balance-display" class="balance-display"></div>
-                    <div id="betting-status-note" class="status-card__note"></div>
                 </div>
-                <div class="status-card rent-card">
-                    <div class="status-card__label">Rent Due</div>
-                    <div class="status-card__value" id="rent-amount-text">$0</div>
-                    <div class="status-card__sub">Rolls Left: <span id="rent-rolls-text">0</span></div>
-                    <div class="status-card__summary" id="rent-summary-text">Rent Due: $400 in 6 rolls</div>
-                </div>
-                <div class="status-card multiplier-card">
-                    <div class="status-card__label">Multiplier</div>
-                    <div class="status-card__value" id="multiplier-value">1.00x</div>
-                    <div class="status-card__sub" id="multiplier-breakdown">Stack wins to power up.</div>
-                </div>
-                <div class="status-card earnings-card" id="earnings-card">
-                    <div class="status-card__label">Earnings / Sec</div>
-                    <div class="status-card__value">$<span id="earnings-per-second">0.00</span></div>
-                    <div class="status-card__sub" id="earnings-trend">Awaiting action…</div>
+                <div class="status-hud__secondary">
+                    <div class="status-card rent-card">
+                        <div class="status-card__label">Rent Due</div>
+                        <div class="status-card__value" id="rent-amount-text">$0</div>
+                        <div class="status-card__sub">Rolls Left: <span id="rent-rolls-text">0</span></div>
+                        <div class="status-card__summary" id="rent-summary-text">Rent Due: $400 in 6 rolls</div>
+                    </div>
+                    <div class="status-card multiplier-card">
+                        <div class="status-card__label">Multiplier</div>
+                        <div class="status-card__value" id="multiplier-value">1.00x</div>
+                        <div class="status-card__sub" id="multiplier-breakdown">Stack wins to power up.</div>
+                    </div>
+                    <div class="status-card earnings-card" id="earnings-card">
+                        <div class="status-card__label">Earnings / Sec</div>
+                        <div class="status-card__value">$<span id="earnings-per-second">0.00</span></div>
+                        <div class="status-card__sub" id="earnings-trend">Awaiting action…</div>
+                    </div>
                 </div>
             </div>
 
@@ -158,38 +162,44 @@
                 <span class="earnings-banner__value">$<span id="earnings-per-second">0.00</span></span>
             </div>
 
-            <div id="controls" class="control-panel">
-                <img id="rollButton" src="/images/Button_RollDice.gif" alt="Roll Dice" class="button-image">
-                <input type="number" id="betAmount" class="pill-input" placeholder="Enter Bet Amount" min="1">
-                <img id="betButton" src="/images/Button_PlaceBet.gif" alt="Place Bet" class="button-image">
-                <img id="bet25Button" src="/images/Button_Bet25.gif" alt="Bet 25%" class="button-image">
-                <img id="bet50Button" src="/images/Button_Bet50.gif" alt="Bet 50%" class="button-image">
-                <img id="bet100Button" src="/images/Button_Bet100.gif" alt="Bet 100%" class="button-image">
-                <button id="quitButton" class="chip-button danger">Quit Game</button>
-            </div>
-
-            <div id="crypto-section" class="neon-panel">
-                <button id="pay-with-bitcoin" class="crypto-chip">
-                    <span class="crypto-chip__icon">₿</span>
-                    <span>Pay with Bitcoin (Kraken)</span>
-                </button>
-
-                <button id="connect-metamask" class="crypto-chip">
-                    <img src="/images/MetaMask_Fox.png" alt="MetaMask">
-                    <span>Connect MetaMask</span>
-                </button>
-
-                <div class="crypto-input">
-                    <img src="/images/ETH_Logo.png" alt="ETH" class="crypto-input__icon">
-                    <input type="number" id="betAmountETH" placeholder="Enter Bet in ETH" step="0.01" min="0">
+            <div class="control-stack">
+                <div id="controls" class="control-panel">
+                    <img id="rollButton" src="/images/Button_RollDice.gif" alt="Roll Dice" class="button-image">
+                    <input type="number" id="betAmount" class="pill-input" placeholder="Enter Bet Amount" min="1">
+                    <img id="betButton" src="/images/Button_PlaceBet.gif" alt="Place Bet" class="button-image">
+                    <img id="bet25Button" src="/images/Button_Bet25.gif" alt="Bet 25%" class="button-image">
+                    <img id="bet50Button" src="/images/Button_Bet50.gif" alt="Bet 50%" class="button-image">
+                    <img id="bet100Button" src="/images/Button_Bet100.gif" alt="Bet 100%" class="button-image">
+                    <button id="quitButton" class="chip-button danger">Quit Game</button>
                 </div>
-                <img id="eth-bet-button" src="/images/Button_PlaceBet.gif" alt="Place Bet (ETH)" class="button-image crypto-bet-button">
-            </div>
 
-            <div class="crypto-instructions">
-                <span class="crypto-instructions__label">Kraken BTC Address:</span>
-                <code id="kraken-btc-address">3BuG5H7qyEVsnRk7cs6i2sgjYoRVGEHXtb</code>
-                <button id="copy-kraken-address" class="chip-button chip-button--compact">Copy Address</button>
+                <div id="crypto-section" class="crypto-strip">
+                    <div class="crypto-strip__row">
+                        <button id="pay-with-bitcoin" class="chip-button chip-button--compact crypto-action">
+                            <span class="crypto-action__icon">₿</span>
+                            <span>Pay with Bitcoin (Kraken)</span>
+                        </button>
+
+                        <button id="connect-metamask" class="chip-button chip-button--compact crypto-action">
+                            <img src="/images/MetaMask_Fox.png" alt="MetaMask">
+                            <span>Connect MetaMask</span>
+                        </button>
+
+                        <button id="copy-kraken-address" class="chip-button chip-button--compact crypto-action">Copy Address</button>
+                    </div>
+
+                    <div class="crypto-strip__row crypto-strip__row--entry">
+                        <div class="crypto-input">
+                            <img src="/images/ETH_Logo.png" alt="ETH" class="crypto-input__icon">
+                            <input type="number" id="betAmountETH" placeholder="Enter Bet in ETH" step="0.01" min="0">
+                        </div>
+                        <button id="eth-place-bet" class="chip-button chip-button--compact crypto-action is-disabled" disabled>Place Bet (ETH)</button>
+                        <div class="crypto-strip__address">
+                            <span class="crypto-strip__address-label">Kraken BTC:</span>
+                            <code id="kraken-btc-address">3BuG5H7qyEVsnRk7cs6i2sgjYoRVGEHXtb</code>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <!-- Game Over Section -->

--- a/public/modules/dice.js
+++ b/public/modules/dice.js
@@ -7,15 +7,16 @@ export function rollDice() {
     };
 }
 
-export function animateDice(dice1, dice2, callback) {
+export function animateDice(dice1, dice2, callback, options = {}) {
+    const { onFire = false } = options;
     const dice1Element = document.getElementById('dice1');
     const dice2Element = document.getElementById('dice2');
 
     let counter = 0;
     const interval = setInterval(() => {
-        const dice1Src = `/images/${onFire ? 'DiceFire' : 'dice'}${Math.floor(Math.random() * 6) + 1}${onFire ? '.gif' : '.png'}`;
-        const dice2Src = `/images/${onFire ? 'DiceFire' : 'dice'}${Math.floor(Math.random() * 6) + 1}${onFire ? '.gif' : '.png'}`;
-        
+        const dice1Src = `/images/${onFire ? 'DiceFire' : 'dice'}${Math.floor(Math.random() * 6) + 1}${onFire ? '.gif' : '.gif'}`;
+        const dice2Src = `/images/${onFire ? 'DiceFire' : 'dice'}${Math.floor(Math.random() * 6) + 1}${onFire ? '.gif' : '.gif'}`;
+
         dice1Element.src = dice1Src;
         dice2Element.src = dice2Src;
 
@@ -36,8 +37,8 @@ export function animateDice(dice1, dice2, callback) {
 
         if (counter >= 10) {
             clearInterval(interval);
-            dice1Element.src = `/images/${onFire ? 'DiceFire' : 'dice'}${dice1}${onFire ? '.gif' : '.png'}`;
-            dice2Element.src = `/images/${onFire ? 'DiceFire' : 'dice'}${dice2}${onFire ? '.gif' : '.png'}`;
+            dice1Element.src = `/images/${onFire ? 'DiceFire' : 'dice'}${dice1}${onFire ? '.gif' : '.gif'}`;
+            dice2Element.src = `/images/${onFire ? 'DiceFire' : 'dice'}${dice2}${onFire ? '.gif' : '.gif'}`;
             callback();
         }
     }, 100);

--- a/public/modules/ui.js
+++ b/public/modules/ui.js
@@ -189,7 +189,7 @@ export function updateUI(balance = 0, rent = 0, turns = 0, maxTurns = 0, current
     }
 }
 
-const MAX_ROLL_HISTORY = 6;
+const MAX_ROLL_HISTORY = 3;
 const recentRolls = [];
 
 export function recordRecentRoll(dice1, dice2, sum) {
@@ -212,11 +212,26 @@ export function recordRecentRoll(dice1, dice2, sum) {
         sumBadge.className = 'roll-history__sum';
         sumBadge.textContent = sum.toString();
 
+        const diceGroup = document.createElement('div');
+        diceGroup.className = 'roll-history__dice-group';
+
+        const icons = document.createElement('div');
+        icons.className = 'roll-history__icons';
+
+        [dice1, dice2].forEach((value, index) => {
+            const icon = document.createElement('img');
+            icon.className = 'roll-history__icon';
+            icon.src = `/images/dice${value}.gif`;
+            icon.alt = `Die ${index + 1}: ${value}`;
+            icons.appendChild(icon);
+        });
+
         const diceBreakdown = document.createElement('span');
         diceBreakdown.className = 'roll-history__dice';
         diceBreakdown.textContent = `${dice1} + ${dice2}`;
 
-        entry.append(sumBadge, diceBreakdown);
+        diceGroup.append(icons, diceBreakdown);
+        entry.append(sumBadge, diceGroup);
         list.appendChild(entry);
     });
 }

--- a/public/style.css
+++ b/public/style.css
@@ -54,10 +54,10 @@ body {
     background-color: #02030b;
     color: #f7f8ff;
     margin: 0;
-    padding: 24px 28px;
+    padding: 24px;
     display: flex;
     justify-content: center;
-    align-items: flex-start;
+    align-items: stretch;
     min-height: 100vh;
     flex-direction: column;
     background-size: cover;
@@ -66,6 +66,7 @@ body {
     box-sizing: border-box;
     position: relative;
     overflow-x: hidden;
+    gap: 16px;
 }
 
 body.drawer-visible {
@@ -93,16 +94,17 @@ body::before {
     border-radius: 22px;
     border: 1px solid rgba(120, 186, 255, 0.16);
     box-shadow: 0 22px 48px rgba(2, 2, 12, 0.55);
-    width: min(1180px, 94vw);
+    width: min(1280px, 100%);
+    height: calc(100vh - 72px);
     padding: 24px;
     color: #f7f8ff;
     display: grid;
-    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    grid-template-columns: minmax(280px, 320px) minmax(0, 1fr);
     gap: 24px;
     align-items: stretch;
     box-sizing: border-box;
     backdrop-filter: blur(18px);
-    overflow: visible;
+    overflow: hidden;
     z-index: 1;
 }
 
@@ -215,15 +217,29 @@ h1 {
 }
 
 #status-hud {
-    display: grid;
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
     gap: 16px;
 }
 
-@media (min-width: 1080px) {
-    #status-hud {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
+.status-hud__primary {
+    display: flex;
+}
+
+.status-hud__primary .status-card {
+    flex: 1;
+    min-width: 0;
+}
+
+.status-hud__secondary {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.status-hud__secondary .status-card {
+    flex: 1 1 160px;
+    min-width: 0;
 }
 
 .status-card {
@@ -838,8 +854,8 @@ h1 {
     padding: 18px 16px;
     border-radius: 18px;
     color: #f7f8ff;
-    max-height: none;
-    overflow: visible;
+    height: 100%;
+    overflow-y: auto;
     box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.22);
     border: 1px solid rgba(120, 186, 255, 0.18);
     backdrop-filter: blur(10px);
@@ -863,6 +879,27 @@ h1 {
     #left-side,
     #right-side {
         max-height: none;
+    }
+
+    .status-hud__primary,
+    .status-hud__secondary {
+        flex-direction: column;
+    }
+
+    .status-hud__secondary {
+        gap: 12px;
+    }
+
+    .crypto-strip__row--entry {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    .crypto-strip__row--entry .crypto-action,
+    .crypto-strip__address {
+        width: 100%;
+        justify-content: space-between;
     }
 }
 
@@ -936,8 +973,8 @@ h1 {
     align-items: stretch;
     gap: 18px;
     padding: 12px 4px 12px;
-    max-height: none;
-    overflow: visible;
+    height: 100%;
+    overflow-y: auto;
 }
 
 #right-side::-webkit-scrollbar {
@@ -1029,7 +1066,7 @@ h1 {
 .roll-history {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 16px;
     padding: 12px 16px;
     border-radius: 16px;
     border: 1px solid rgba(120, 186, 255, 0.18);
@@ -1047,21 +1084,42 @@ h1 {
 
 .roll-history__list {
     display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
+    align-items: center;
+    gap: 12px;
     justify-content: flex-start;
+    flex: 1;
 }
 
 .roll-history__entry {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 6px 10px;
+    gap: 10px;
+    padding: 6px 12px;
     border-radius: 12px;
     border: 1px solid rgba(120, 186, 255, 0.22);
     background: rgba(12, 22, 48, 0.38);
     box-shadow: 0 8px 16px rgba(6, 12, 28, 0.28);
-    min-width: 92px;
+    min-width: 120px;
+}
+
+.roll-history__dice-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.roll-history__icons {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.roll-history__icon {
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    object-fit: contain;
+    filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.35));
 }
 
 .roll-history__sum {
@@ -1130,6 +1188,23 @@ h1 {
     width: 100%;
 }
 
+.control-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.neon-panel {
+    border-radius: 18px;
+    border: 1px solid rgba(120, 186, 255, 0.2);
+    background: rgba(8, 16, 44, 0.32);
+    box-shadow: 0 16px 24px rgba(4, 10, 24, 0.32);
+    padding: 20px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
 .control-panel .button-image {
     width: 118px;
     transition: transform 0.2s ease, filter 0.2s ease;
@@ -1151,15 +1226,70 @@ h1 {
     padding: 12px 26px;
 }
 
-.neon-panel {
-    border-radius: 18px;
-    border: 1px solid rgba(120, 186, 255, 0.2);
-    background: rgba(8, 16, 44, 0.32);
-    box-shadow: 0 16px 24px rgba(4, 10, 24, 0.32);
-    padding: 20px 22px;
+.crypto-strip {
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 10px;
+    padding: 12px 16px;
+    border-radius: 16px;
+    border: 1px solid rgba(120, 186, 255, 0.2);
+    background: rgba(8, 16, 44, 0.28);
+    box-shadow: 0 12px 22px rgba(4, 10, 24, 0.25);
+}
+
+.crypto-strip__row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.crypto-strip__row--entry {
+    justify-content: space-between;
+}
+
+.crypto-strip__row--entry .crypto-input {
+    flex: 1 1 220px;
+}
+
+.crypto-strip__row--entry .crypto-action {
+    flex-shrink: 0;
+}
+
+.crypto-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+}
+
+.crypto-action img {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+}
+
+.crypto-action .crypto-action__icon {
+    font-size: 1rem;
+}
+
+.crypto-strip__address {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.75rem;
+    color: rgba(186, 206, 255, 0.78);
+    justify-content: flex-start;
+    white-space: normal;
+    word-break: break-all;
+}
+
+.crypto-strip__address code {
+    font-size: 0.8rem;
+    color: #7fbcf7;
+    background: rgba(12, 24, 54, 0.6);
+    padding: 4px 8px;
+    border-radius: 8px;
 }
 
 #fortune-area {
@@ -1944,7 +2074,8 @@ body {
     background: transparent;
     color: #f5f7ff;
     font-weight: 600;
-    width: 110px;
+    width: 100%;
+    min-width: 0;
 }
 
 .crypto-input input::placeholder {
@@ -1993,6 +2124,11 @@ body {
 .chip-button--compact {
     padding: 6px 14px;
     font-size: 0.72rem;
+}
+
+.chip-button.is-disabled {
+    opacity: 0.5;
+    pointer-events: none;
 }
 
 #chat-footer {
@@ -2685,18 +2821,25 @@ img[src="/images/Button_Bet100.gif"]:hover {
 }
 #hud-controls,
 .hud-controls {
-    width: min(1180px, 94vw);
-    margin: 0 auto 16px;
+    position: fixed;
+    left: 24px;
+    bottom: 24px;
+    width: auto;
+    margin: 0;
     display: flex;
-    justify-content: flex-end;
-    position: relative;
-    z-index: 2;
+    justify-content: flex-start;
+    z-index: 5;
+    pointer-events: none;
+}
+
+.hud-controls .interface-toggle {
+    pointer-events: auto;
 }
 
 .interface-toggle {
     display: inline-flex;
     flex-direction: column;
-    align-items: flex-end;
+    align-items: flex-start;
     gap: 6px;
     padding: 10px 16px;
     border-radius: 16px;


### PR DESCRIPTION
## Summary
- restyle the HUD and utility controls so the game board fills the desktop viewport with the chat toggle anchored bottom-left
- compress the crypto actions into a slim support strip with compact buttons and add dice icons to the limited roll history display
- fix dice animation to honor the on-fire state while tightening ETH bet handling and feedback

## Testing
- npm start *(fails: server expects wallet configuration for ethers SigningKey)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b5b48624832db550b2489447bc2f