### PR TITLE
Fix dice animation sizing and layout

### DIFF
--- a/public/modules/dice.js
+++ b/public/modules/dice.js
@@ -21,65 +21,33 @@ export function animateDice(dice1, dice2, callback, options = {}) {
     const dice1Element = document.getElementById('dice1');
     const dice2Element = document.getElementById('dice2');
 
-    console.group('[Dice] Starting animation');
-    console.log('Final target values', { dice1, dice2, onFire });
-
     if (!dice1Element || !dice2Element) {
         console.error('[Dice] Dice elements missing in DOM.', { dice1Element, dice2Element });
-        console.groupEnd();
         callback?.();
         return;
     }
 
-    console.log('Dice element references', {
-        dice1ElementPresent: Boolean(dice1Element),
-        dice2ElementPresent: Boolean(dice2Element),
-        dice1CurrentSrc: dice1Element?.src,
-        dice2CurrentSrc: dice2Element?.src,
-    });
+    const spritePrefix = onFire ? 'DiceFire' : 'dice';
+    const spriteExtension = onFire ? '.gif' : '.png';
+    let iterations = 0;
+    const maxIterations = 10;
 
-    let counter = 0;
     const interval = setInterval(() => {
-        const dice1Src = `/images/${onFire ? 'DiceFire' : 'dice'}${Math.floor(Math.random() * 6) + 1}${onFire ? '.gif' : '.gif'}`;
-        const dice2Src = `/images/${onFire ? 'DiceFire' : 'dice'}${Math.floor(Math.random() * 6) + 1}${onFire ? '.gif' : '.gif'}`;
+        const randomDice1 = Math.floor(Math.random() * 6) + 1;
+        const randomDice2 = Math.floor(Math.random() * 6) + 1;
 
-        dice1Element.src = dice1Src;
-        dice2Element.src = dice2Src;
+        dice1Element.src = `/images/${spritePrefix}${randomDice1}${spriteExtension}`;
+        dice2Element.src = `/images/${spritePrefix}${randomDice2}${spriteExtension}`;
 
-        console.debug('[Dice] Animation frame', {
-            iteration: counter,
-            appliedSources: { dice1Src, dice2Src },
-        });
+        iterations += 1;
 
-        // Adjust size for "on fire" state
-        if (onFire) {
-            dice1Element.style.width = '150px'; // Larger width
-            dice1Element.style.height = '150px'; // Larger height
-            dice2Element.style.width = '150px';
-            dice2Element.style.height = '150px';
-        } else {
-            dice1Element.style.width = '100px'; // Standard width
-            dice1Element.style.height = '100px'; // Standard height
-            dice2Element.style.width = '100px';
-            dice2Element.style.height = '100px';
-        }
-
-        counter++;
-
-        if (counter >= 10) {
+        if (iterations >= maxIterations) {
             clearInterval(interval);
-            dice1Element.src = `/images/${onFire ? 'DiceFire' : 'dice'}${dice1}${onFire ? '.gif' : '.gif'}`;
-            dice2Element.src = `/images/${onFire ? 'DiceFire' : 'dice'}${dice2}${onFire ? '.gif' : '.gif'}`;
-            console.log('[Dice] Animation complete. Applying final sources.', {
-                finalDice1Src: dice1Element.src,
-                finalDice2Src: dice2Element.src,
-            });
-            console.groupEnd();
-            callback();
+            dice1Element.src = `/images/${spritePrefix}${dice1}${spriteExtension}`;
+            dice2Element.src = `/images/${spritePrefix}${dice2}${spriteExtension}`;
+            callback?.();
         }
     }, 100);
-
-    console.log('[Dice] Interval established for animation', { intervalId: interval });
 }
 
 

--- a/public/style.css
+++ b/public/style.css
@@ -159,12 +159,13 @@ h1 {
     align-items: center;
     justify-content: center;
     gap: 16px;
-    padding: 26px 24px 24px;
+    padding: 32px 28px 28px;
     background: rgba(6, 12, 32, 0.4);
     border-radius: 24px;
     border: 1px solid rgba(120, 186, 255, 0.22);
     box-shadow: 0 20px 34px rgba(6, 10, 28, 0.45);
     overflow: hidden;
+    min-height: 320px;
 }
 
 #dice-stage::before {
@@ -184,13 +185,15 @@ h1 {
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 32px;
-    padding: 20px 24px;
+    gap: 36px;
+    padding: 28px 32px;
     border-radius: 20px;
     background: rgba(12, 22, 52, 0.42);
     border: 1px solid rgba(120, 186, 255, 0.24);
     box-shadow: inset 0 0 28px rgba(0, 0, 0, 0.45), 0 0 28px rgba(92, 125, 255, 0.28);
     z-index: 1;
+    min-height: 220px;
+    min-width: 320px;
 }
 
 #dice-container::after {
@@ -204,8 +207,8 @@ h1 {
 }
 
 .dice {
-    width: 110px;
-    height: 110px;
+    width: 150px;
+    height: 150px;
     filter: drop-shadow(0 16px 22px rgba(0, 0, 0, 0.55));
     animation: floatDice 4.6s ease-in-out infinite;
     position: relative;
@@ -900,6 +903,20 @@ h1 {
     .crypto-strip__address {
         width: 100%;
         justify-content: space-between;
+    }
+}
+
+@media (max-width: 700px) {
+    #dice-container {
+        flex-wrap: wrap;
+        min-width: unset;
+        min-height: 180px;
+        padding: 24px;
+    }
+
+    .dice {
+        width: 120px;
+        height: 120px;
     }
 }
 


### PR DESCRIPTION
## Summary
- enlarge the dice stage container and dice images to restore the previous presentation
- streamline the dice animation helper so it uses the appropriate sprite set for normal and on-fire rolls

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e4736ef8832db73c056059b91bad