### PR TITLE
Smooth eShop background transitions

### DIFF
--- a/public/modules/shop.css
+++ b/public/modules/shop.css
@@ -3,10 +3,7 @@
 body {
     margin: 0;
     padding: 0;
-    background-image: url('/images/eStore/eShop_Center_Idle_0.gif');
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    background-color: black;
     height: 100vh;
     display: flex;
     justify-content: center;
@@ -46,4 +43,19 @@ body {
     width: 100%;
     height: 100%;
     z-index: -1;
+    overflow: hidden;
+}
+
+.background-layer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0;
+    transition: opacity 400ms ease-in-out;
+}
+
+.background-layer.visible {
+    opacity: 1;
 }

--- a/public/modules/shop.js
+++ b/public/modules/shop.js
@@ -4,15 +4,59 @@ document.addEventListener('DOMContentLoaded', () => {
     const leftButton = document.getElementById('left-button');
     const centerButton = document.getElementById('center-button');
     const rightButton = document.getElementById('right-button');
-    const backgroundContainer = document.body;
+    const backgroundContainer = document.getElementById('background-container');
     const audio = document.getElementById('background-audio');
+
+    const backgroundLayers = [document.createElement('img'), document.createElement('img')];
+    backgroundLayers.forEach(layer => {
+        layer.classList.add('background-layer');
+        backgroundContainer.appendChild(layer);
+    });
+
+    const initialLayer = backgroundLayers[0];
+    initialLayer.classList.add('active', 'visible');
+    initialLayer.dataset.currentSrc = '/images/eStore/eShop_Center_Idle_0.gif';
+    initialLayer.src = '/images/eStore/eShop_Center_Idle_0.gif';
 
     // Play background music
     audio.play();
 
+    function restartImage(element, image) {
+        if (element.dataset.currentSrc === image) {
+            element.src = '';
+        }
+
+        element.dataset.currentSrc = image;
+        element.src = image;
+    }
+
+    function setActiveImage(image) {
+        const currentActive = backgroundContainer.querySelector('.background-layer.active');
+
+        if (!currentActive) return;
+
+        restartImage(currentActive, image);
+    }
+
     // Helper function to change background image and execute actions
     function changeBackground(image, callback, duration = 3000) {
-        backgroundContainer.style.backgroundImage = `url(${image})`;
+        const currentActive = backgroundContainer.querySelector('.background-layer.active');
+        const currentInactive = backgroundContainer.querySelector('.background-layer:not(.active)');
+
+        if (!currentActive || !currentInactive) {
+            if (callback) {
+                setTimeout(callback, duration);
+            }
+            return;
+        }
+
+        restartImage(currentInactive, image);
+
+        requestAnimationFrame(() => {
+            currentInactive.classList.add('visible', 'active');
+            currentActive.classList.remove('visible', 'active');
+        });
+
         setTimeout(() => {
             if (callback) callback();
         }, duration);
@@ -22,7 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
     leftButton.addEventListener('click', () => {
         document.getElementById('button-container').style.display = 'none';
         changeBackground('/images/eStore/eShop_Center_to_Left_0.gif', () => {
-            backgroundContainer.style.backgroundImage = "url('/images/eStore/eShop_Left_Idle_0.gif')";
+            setActiveImage('/images/eStore/eShop_Left_Idle_0.gif');
             audio.src = '/sounds/eShopSFX_Fire_R.mp3';
             audio.play();
 
@@ -49,7 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 buyButton.remove();
                 returnButton.remove();
                 changeBackground('/images/eStore/eShop_Left_to_Center_0.gif', () => {
-                    backgroundContainer.style.backgroundImage = "url('/images/eStore/eShop_Center_Idle_0.gif')";
+                    setActiveImage('/images/eStore/eShop_Center_Idle_0.gif');
                     audio.src = '/sounds/eShopSFX.mp3';
                     audio.play();
                     document.getElementById('button-container').style.display = 'flex';
@@ -62,7 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
     centerButton.addEventListener('click', () => {
         document.getElementById('button-container').style.display = 'none';
         changeBackground('/images/eStore/eShop_Center_to_Logo_0.gif', () => {
-            backgroundContainer.style.backgroundImage = "url('/images/eStore/eShop_Logo_Idle_0.gif')";
+            setActiveImage('/images/eStore/eShop_Logo_Idle_0.gif');
 
             const offeringButton = document.createElement('button');
             const returnButton = document.createElement('button');
@@ -84,7 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 offeringButton.remove();
                 returnButton.remove();
                 changeBackground('/images/eStore/eShop_Logo_to_Center_0.gif', () => {
-                    backgroundContainer.style.backgroundImage = "url('/images/eStore/eShop_Center_Idle_0.gif')";
+                    setActiveImage('/images/eStore/eShop_Center_Idle_0.gif');
                     document.getElementById('button-container').style.display = 'flex';
                 });
             });
@@ -95,7 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
     rightButton.addEventListener('click', () => {
         document.getElementById('button-container').style.display = 'none';
         changeBackground('/images/eStore/eShop_Center_to_Right_0.gif', () => {
-            backgroundContainer.style.backgroundImage = "url('/images/eStore/eShop_Right_Idle_0.gif')";
+            setActiveImage('/images/eStore/eShop_Right_Idle_0.gif');
             audio.src = '/sounds/eShopSFX_Fire_L.mp3';
             audio.play();
 
@@ -119,7 +163,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 buyButton.remove();
                 returnButton.remove();
                 changeBackground('/images/eStore/eShop_Right_to_Center_0.gif', () => {
-                    backgroundContainer.style.backgroundImage = "url('/images/eStore/eShop_Center_Idle_0.gif')";
+                    setActiveImage('/images/eStore/eShop_Center_Idle_0.gif');
                     audio.src = '/sounds/eShopSFX.mp3';
                     audio.play();
                     document.getElementById('button-container').style.display = 'flex';


### PR DESCRIPTION
## Summary
- layer the shop background inside a dedicated container so GIFs can fade instead of snapping
- drive GIF swaps through paired image elements that cross-fade between transition and idle loops
- refresh idle artwork after each move to keep the animation chain seamless

## Testing
- python3 -m http.server 3000 --directory public

------
https://chatgpt.com/codex/tasks/task_e_68d7175861e4832dafd9aa58beee69ac