### PR TITLE
Fix game over trigger and remove roll dimming effect

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -422,11 +422,6 @@ async function setupSinglePlayer() {
                 canRollDice = true;
             }, 200);
 
-            const gameContainer = document.getElementById('game-container');
-            const diceContainer = document.getElementById('dice-container');
-            gameContainer.classList.add('dimmed');
-            diceContainer.classList.add('dimmed-dice');
-
             playSound(["/sounds/DiceShake1.ogg", "/sounds/DiceShake2.ogg", "/sounds/DiceShake3.ogg"], true);
 
             let rollResult = rollDice();
@@ -494,6 +489,10 @@ async function setupSinglePlayer() {
                     winStreak = 0;
                     if (onFire) deactivateOnFire();
                     outcome = 'loss';
+
+                    if (balance <= 0) {
+                        handleGameOver();
+                    }
                 } else {
                     if (cashBonus) {
                         adjustBalance(cashBonus);
@@ -528,11 +527,6 @@ async function setupSinglePlayer() {
                 refreshStatusPanel();
                 refreshBetButtons();
                 updateUIAfterRoll();
-
-                setTimeout(() => {
-                    gameContainer.classList.remove('dimmed');
-                    diceContainer.classList.remove('dimmed-dice');
-                }, 1000);
             });
         }
 


### PR DESCRIPTION
## Summary
- ensure losing all funds triggers the game over handler immediately during a roll
- remove the temporary screen dimming classes that were applied while dice rolled

## Testing
- npm start *(fails: missing optional dependency mongodb)*

------
https://chatgpt.com/codex/tasks/task_e_68d92a39c804832d8ad68954a7686f86