### PR TITLE
Improve game over overlays and unify leaderboard actions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -243,8 +243,6 @@ async function setupSinglePlayer() {
 
         if (balance > 1) {
             displayLeaderboardPrompt(balance);
-        } else {
-            alert('Game Over! Better luck next time.');
         }
     }
 
@@ -1008,11 +1006,23 @@ function animateDice(dice1, dice2, callback) {
         gameOverContainer.style.display = 'flex';
         gameOverContainer.innerHTML = '';
 
-        const gameOverImage = document.createElement('img');
-        gameOverImage.src = '/images/GameOverEvicted.gif';
-        gameOverImage.alt = 'Game Over';
-        gameOverImage.className = 'game-over-visual';
-        gameOverContainer.appendChild(gameOverImage);
+        gameOverContainer.style.backgroundImage = "url('/images/GameOverEvicted.gif')";
+        gameOverContainer.style.backgroundSize = 'cover';
+        gameOverContainer.style.backgroundPosition = 'center';
+        gameOverContainer.style.backgroundRepeat = 'no-repeat';
+
+        const contentContainer = document.createElement('div');
+        contentContainer.className = 'game-over-content';
+
+        const title = document.createElement('h2');
+        title.className = 'game-over-title';
+        title.textContent = 'Evicted! Game Over';
+        contentContainer.appendChild(title);
+
+        const subtitle = document.createElement('p');
+        subtitle.className = 'game-over-subtitle';
+        subtitle.textContent = 'Better luck next time!';
+        contentContainer.appendChild(subtitle);
 
         const buttonsContainer = document.createElement('div');
         buttonsContainer.className = 'game-over-actions';
@@ -1020,6 +1030,7 @@ function animateDice(dice1, dice2, callback) {
         const restartButton = document.createElement('button');
         restartButton.type = 'button';
         restartButton.textContent = 'Restart';
+        restartButton.className = 'game-over-action-button';
         restartButton.addEventListener('click', () => {
             window.location.reload();
         });
@@ -1027,13 +1038,19 @@ function animateDice(dice1, dice2, callback) {
         const quitButton = document.createElement('button');
         quitButton.type = 'button';
         quitButton.textContent = 'Quit Game';
+        quitButton.className = 'game-over-action-button game-over-action-button--danger';
         quitButton.addEventListener('click', () => {
             window.location.href = '/';
         });
 
         buttonsContainer.appendChild(restartButton);
         buttonsContainer.appendChild(quitButton);
-        gameOverContainer.appendChild(buttonsContainer);
+        contentContainer.appendChild(buttonsContainer);
+        gameOverContainer.appendChild(contentContainer);
+
+        setTimeout(() => {
+            gameOverContainer.style.backgroundImage = "url('/images/GameOverIdleScreen.png')";
+        }, 6000);
     }
     
 
@@ -1405,10 +1422,21 @@ async function displayLeaderboardPrompt(score) {
     const playerNameInput = document.getElementById("player-name");
     const submitButton = document.getElementById("submit-leaderboard");
     const leaderboardDisplay = document.getElementById("leaderboard-entries");
+    const promptContainer = document.getElementById("leaderboard-prompt");
+
+    let buttonRow = document.getElementById("leaderboard-button-row");
+    if (!buttonRow) {
+        buttonRow = document.createElement("div");
+        buttonRow.id = "leaderboard-button-row";
+    }
+    buttonRow.className = 'game-over-actions';
+    buttonRow.innerHTML = '';
 
     // Clear previous buttons if any
-    const quitButtonExists = document.getElementById("quit-leaderboard");
-    if (quitButtonExists) quitButtonExists.remove();
+    const existingQuit = document.getElementById("quit-leaderboard");
+    if (existingQuit) existingQuit.remove();
+    const existingRestart = document.getElementById("restart-leaderboard");
+    if (existingRestart) existingRestart.remove();
 
     overlay.style.display = "flex";
 
@@ -1429,15 +1457,31 @@ async function displayLeaderboardPrompt(score) {
         leaderboardDisplay.innerHTML = "<p>Unable to load leaderboard.</p>";
     }
 
-    // Create a Quit Game button dynamically
+    submitButton.classList.add('game-over-action-button');
+    submitButton.type = 'button';
+
+    // Create restart and quit buttons dynamically
+    const restartButton = document.createElement("button");
+    restartButton.id = "restart-leaderboard";
+    restartButton.type = "button";
+    restartButton.textContent = "Restart";
+    restartButton.className = 'game-over-action-button';
+    restartButton.onclick = () => window.location.reload();
+
     const quitButton = document.createElement("button");
     quitButton.id = "quit-leaderboard";
     quitButton.textContent = "Quit Game";
-    quitButton.style.marginLeft = "10px"; // Add spacing from the Submit button
+    quitButton.type = 'button';
+    quitButton.className = 'game-over-action-button game-over-action-button--danger';
     quitButton.onclick = window.quitGame; // Use the globally attached quitGame function
 
-    // Add the Quit Game button next to Submit button
-    submitButton.parentNode.insertBefore(quitButton, submitButton.nextSibling);
+    buttonRow.appendChild(submitButton);
+    buttonRow.appendChild(restartButton);
+    buttonRow.appendChild(quitButton);
+
+    if (promptContainer) {
+        promptContainer.appendChild(buttonRow);
+    }
 
     // Submit leaderboard entry
     submitButton.onclick = async () => {

--- a/public/game.html
+++ b/public/game.html
@@ -180,13 +180,13 @@
 </div>
 
 <div id="leaderboard-overlay" style="display: none;">
-    <div id="leaderboard-prompt">
-        <h2>Enter Your Name for the Leaderboard</h2>
+    <div id="leaderboard-prompt" class="game-over-content">
+        <h2 class="game-over-title">Enter Your Name for the Leaderboard</h2>
         <input type="text" id="player-name" placeholder="Your Name" maxlength="20" />
         <button id="submit-leaderboard">Submit</button>
     </div>
     <div id="leaderboard-display">
-        <h2>Global Leaderboard</h2>
+        <h2 class="game-over-title">Global Leaderboard</h2>
         <div id="leaderboard-entries"></div>
     </div>
 </div>

--- a/public/style.css
+++ b/public/style.css
@@ -991,11 +991,13 @@ h1 {
     height: 100%;
     height: 1; /* Adjust height based on content */
     background: url('/images/GameOverEvicted.gif') center center no-repeat; /* Add background image */
-    background-size: 100% 100%; /* Stretch image to fully fill the container */;
+    background-size: cover; /* Stretch image to fully fill the container */;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 32px;
+    padding: 32px;
     z-index: 9999;
 }
 
@@ -1009,6 +1011,18 @@ h1 {
     padding: 10px;
     font-size: 16px;
     margin-bottom: 10px;
+    width: 100%;
+    border-radius: 999px;
+    border: none;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.9);
+    color: #1d1d1d;
+    box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.15);
+}
+
+#player-name:focus {
+    outline: none;
+    box-shadow: inset 0 0 0 2px rgba(255, 184, 77, 0.8);
 }
 
 #leaderboard-display {
@@ -1340,23 +1354,6 @@ body {
     transform-origin: center center; /* Ensure the tilt originates from the screen's center */
     perspective: 1000px; /* Add 3D perspective for a more realistic tilt effect */
     transition: transform 0.1s ease; /* Smooth transition for the tilt */
-}
-#submit-leaderboard,
-#quit-leaderboard {
-    display: inline-block;
-    margin: 10px;
-    padding: 8px 20px;
-    font-size: 18px;
-    cursor: pointer;
-    border: 1px solid #ff2929;
-    border-radius: 5px;
-    background-color: #797979;
-    transition: background-color 0.2s;
-}
-
-#submit-leaderboard:hover,
-#quit-leaderboard:hover {
-    background-color: #605858;
 }
 #balance-display img {
     display: inline-block;
@@ -1727,6 +1724,7 @@ body {
 }
 
 
+
 .game-over-overlay {
     position: fixed;
     inset: 0;
@@ -1734,28 +1732,61 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: 28px;
+    gap: 0;
     background: rgba(0, 0, 0, 0.92);
     z-index: 9999;
-    padding: 24px;
+    padding: 32px;
 }
 
 .game-over-visual {
-    width: min(90vw, 780px);
+    width: min(95vw, 1100px);
     height: auto;
-    max-height: 80vh;
+    max-height: 100vh;
     object-fit: contain;
     border-radius: 12px;
     box-shadow: 0 25px 55px rgba(0, 0, 0, 0.65);
 }
 
+.game-over-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    padding: 32px 36px;
+    border-radius: 20px;
+    background: rgba(0, 0, 0, 0.55);
+    box-shadow: 0 35px 65px rgba(0, 0, 0, 0.65);
+    backdrop-filter: blur(6px);
+    width: min(90vw, 560px);
+    max-width: 100%;
+}
+
+.game-over-title {
+    font-size: clamp(2rem, 3vw, 3rem);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #ffe8a3;
+    text-shadow: 0 18px 36px rgba(0, 0, 0, 0.65);
+    margin: 0;
+}
+
+.game-over-subtitle {
+    margin: 0;
+    font-size: 1.1rem;
+    color: #fff5d9;
+    letter-spacing: 0.05em;
+    text-align: center;
+}
+
 .game-over-actions {
     display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 18px;
 }
 
-.game-over-actions button {
-    padding: 12px 28px;
+.game-over-action-button {
+    padding: 12px 30px;
     font-size: 1rem;
     font-weight: 700;
     letter-spacing: 0.08em;
@@ -1769,17 +1800,18 @@ body {
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.game-over-actions button:nth-child(2) {
+.game-over-action-button--danger {
     background: linear-gradient(135deg, #ff0844, #ffb199);
     color: #fff6f0;
+    box-shadow: 0 16px 30px rgba(255, 38, 88, 0.35);
 }
 
-.game-over-actions button:hover {
+.game-over-action-button:hover {
     transform: translateY(-3px);
     box-shadow: 0 18px 36px rgba(255, 119, 59, 0.45);
 }
 
-.game-over-actions button:active {
+.game-over-action-button:active {
     transform: translateY(0);
 }
 


### PR DESCRIPTION
## Summary
- remove the fallback game over alert when the player busts out
- restyle the zero-balance game over overlay with a full-screen background, title, and shared action buttons
- update the leaderboard prompt to reuse the same button styling and add a restart option alongside submit and quit

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68d93a588400832db8d716c398f0db3f