### PR TITLE
Improve fire multiplier feedback and shop UX

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -283,15 +283,42 @@ h1 {
         transition: box-shadow 0.3s ease, transform 0.3s ease, filter 0.3s ease;
     }
 
+    #store-image.glow-effect {
+        display: block;
+        filter: drop-shadow(0 0 4px rgba(255, 200, 80, 0.45));
+    }
+
     body.fire-active .glow-effect {
         box-shadow: 0 0 28px rgba(255, 0, 0, 0.85), 0 0 55px rgba(255, 60, 0, 0.75) !important;
         filter: drop-shadow(0 0 6px rgba(255, 40, 0, 0.55));
     }
 
+    body.fire-active #store-image.glow-effect {
+        box-shadow: none !important;
+        filter: drop-shadow(0 0 6px rgba(255, 130, 0, 0.75))
+            drop-shadow(0 0 14px rgba(255, 70, 0, 0.6));
+    }
+
     body.fire-active .glow-effect:hover {
         box-shadow: 0 0 34px rgba(255, 70, 0, 0.95), 0 0 70px rgba(255, 30, 0, 0.8) !important;
     }
-    
+
+    body.shop-active #betButton,
+    body.shop-active #bet25Button,
+    body.shop-active #bet50Button,
+    body.shop-active #bet100Button,
+    body.shop-active #eth-bet-button {
+        visibility: hidden;
+        pointer-events: none;
+    }
+
+    body.shop-active #betAmount,
+    body.shop-active #betAmountETH {
+        pointer-events: none;
+        cursor: not-allowed;
+        opacity: 0.6;
+    }
+
 
     #rollButton, #betButton, #quitButton, #bet25Button, #bet50Button, #bet100Button {
         width: 100%;


### PR DESCRIPTION
## Summary
- show the total payout multiplier in the roll summary so on-fire streaks and other boosts are visible to the player
- disable and hide bet controls while the shop is open, reset the bet amount, and refine the store glow styling for fire mode
- display the GameOverEvicted.gif as an image so the artwork stays legible across the full screen

## Testing
- npm install *(fails: 403 Forbidden when downloading mongodb)*

------
https://chatgpt.com/codex/tasks/task_e_68d94232ca40832d9c13a33512ce1558