### PR TITLE
Make game-over visual fill the viewport

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1763,18 +1763,25 @@ body {
     background: rgba(0, 0, 0, 0.92);
     z-index: 9999;
     padding: 32px;
+    box-sizing: border-box;
+    overflow: hidden;
 }
 
 .game-over-visual {
-    width: min(95vw, 1100px);
-    height: auto;
-    max-height: 100vh;
-    object-fit: contain;
-    border-radius: 12px;
-    box-shadow: 0 25px 55px rgba(0, 0, 0, 0.65);
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+    box-shadow: none;
+    z-index: 0;
+    pointer-events: none;
 }
 
 .game-over-content {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
## Summary
- update the game-over overlay to prevent scrolling and treat the GIF as a full-screen background
- ensure the overlay content layers above the animation while maintaining readability

## Testing
- npm install *(fails: 403 Forbidden from registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d94aee8f5c832db62d4fcb64fd8f6d