### PR TITLE
Refine shop layout and enforce whole-dollar scoring

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -344,7 +344,7 @@ async function setupSinglePlayer() {
 
         const buyItemContainerElement = document.getElementById('buy-item-container');
         if (buyItemContainerElement) {
-            buyItemContainerElement.style.display = 'block';
+            buyItemContainerElement.style.display = 'flex';
         }
 
         showItemPopup(config);
@@ -410,7 +410,8 @@ async function setupSinglePlayer() {
 
     function adjustBalance(delta, { track = true } = {}) {
         const previous = balance;
-        balance = Math.max(0, Math.round((balance + delta) * 100) / 100);
+        const nextBalance = Math.round(balance + delta);
+        balance = Math.max(0, nextBalance);
         updateBalanceDisplay(balance);
         updateUI(balance, rent, turns, maxTurns, currentBet);
         if (track) {
@@ -517,10 +518,10 @@ async function setupSinglePlayer() {
             if (typeof input === 'number' && input <= 1) {
                 amount = Math.floor(balance * input);
             } else {
-                amount = Number(input);
+                amount = Math.round(Number(input));
             }
 
-            if (Number.isNaN(amount)) {
+            if (!Number.isFinite(amount)) {
                 showGameMessage('Please enter a valid bet amount.', 'warning');
                 return;
             }
@@ -535,7 +536,7 @@ async function setupSinglePlayer() {
                 return;
             }
 
-            currentBet = Math.floor(amount);
+            currentBet = Math.round(amount);
             if (betInput) {
                 betInput.value = currentBet;
             }
@@ -564,8 +565,6 @@ async function setupSinglePlayer() {
                 canRollDice = true;
             }, 200);
 
-            playSound(["/sounds/DiceShake1.ogg", "/sounds/DiceShake2.ogg", "/sounds/DiceShake3.ogg"], true);
-
             let rollResult = rollDice();
             let { dice1, dice2 } = rollResult;
             let sum = dice1 + dice2;
@@ -579,7 +578,7 @@ async function setupSinglePlayer() {
             }
 
             const { multiplier, cashBonus: hustlerCashBonus } = applyHustlerEffects(dice1, dice2);
-            const cashBonus = Number.isFinite(hustlerCashBonus) ? hustlerCashBonus : 0;
+            const cashBonus = Number.isFinite(hustlerCashBonus) ? Math.round(hustlerCashBonus) : 0;
             const effectiveMultiplier = calculateEffectiveMultiplier(multiplier);
 
             itemEffectsManager.recordRoll({ dice1, dice2, sum });
@@ -610,8 +609,10 @@ async function setupSinglePlayer() {
                         dice2,
                     });
                     const traitBonus = (traitResult?.multiplierBonus || 0) + (traitResult?.flatCashAdd || 0);
-                    totalBonus += traitBonus;
-                    winnings = baseWinnings + cashBonus + traitBonus;
+                    const roundedTraitBonus = Math.round(traitBonus);
+                    totalBonus += roundedTraitBonus;
+                    const rawWinnings = baseWinnings + cashBonus + roundedTraitBonus;
+                    winnings = Math.max(0, Math.round(rawWinnings));
                     finalBalance = adjustBalance(winnings);
                     gameStatus.textContent = `You win! 🎉 Roll: ${sum}`;
                     playSound("/sounds/Winner_0.ogg");
@@ -637,10 +638,11 @@ async function setupSinglePlayer() {
                     });
                     finalBalance = adjustBalance(-currentBet);
                     const lossBonus = (traitResult?.multiplierBonus || 0) + (traitResult?.flatCashAdd || 0);
-                    if (lossBonus !== 0) {
-                        winnings = lossBonus;
-                        finalBalance = adjustBalance(lossBonus);
-                        totalBonus += lossBonus;
+                    const roundedLossBonus = Math.round(lossBonus);
+                    if (roundedLossBonus !== 0) {
+                        winnings = roundedLossBonus;
+                        finalBalance = adjustBalance(roundedLossBonus);
+                        totalBonus += roundedLossBonus;
                     }
                     gameStatus.textContent = `You lose! 💔 Roll: ${sum}`;
                     playSound("/sounds/Loser_0.ogg");
@@ -665,14 +667,15 @@ async function setupSinglePlayer() {
                         dice1,
                         dice2,
                     });
-                    const neutralBonus = cashBonus + (traitResult?.multiplierBonus || 0) + (traitResult?.flatCashAdd || 0);
+                    const neutralBonusRaw = cashBonus + (traitResult?.multiplierBonus || 0) + (traitResult?.flatCashAdd || 0);
+                    const neutralBonus = Math.round(neutralBonusRaw);
                     totalBonus = neutralBonus;
                     if (neutralBonus !== 0) {
                         winnings = neutralBonus;
                         finalBalance = adjustBalance(neutralBonus);
                     }
                     const multiplierText = formatMultiplierValue(effectiveMultiplier);
-                    gameStatus.textContent = `Roll: ${sum}. Multiplier: ${multiplierText}x. Bonus: $${neutralBonus}`;
+                    gameStatus.textContent = `Roll: ${sum}. Multiplier: ${multiplierText}x. Bonus: $${neutralBonus.toLocaleString()}`;
                 }
 
                 itemEffectsManager.finalizeResolve({
@@ -700,10 +703,11 @@ async function setupSinglePlayer() {
                 const passiveIncome = itemEffectsManager.getPassiveIncome();
                 const rollBonus = itemEffectsManager.applyRollBonuses({ dice1, dice2, sum });
                 const totalItemIncome = (passiveIncome || 0) + (rollBonus || 0);
-                if (totalItemIncome !== 0) {
-                    adjustBalance(totalItemIncome);
-                    showGameMessage(`${totalItemIncome > 0 ? '+' : ''}$${Math.abs(totalItemIncome).toLocaleString()} from items`,
-                        totalItemIncome > 0 ? 'bonus' : 'warning',
+                const roundedItemIncome = Math.round(totalItemIncome);
+                if (roundedItemIncome !== 0) {
+                    adjustBalance(roundedItemIncome);
+                    showGameMessage(`${roundedItemIncome > 0 ? '+' : ''}$${Math.abs(roundedItemIncome).toLocaleString()} from items`,
+                        roundedItemIncome > 0 ? 'bonus' : 'warning',
                         { duration: 2600 });
                 }
 

--- a/public/game.html
+++ b/public/game.html
@@ -97,7 +97,7 @@
                 <!-- Balance images will be displayed here -->
             </div>
             <div id="earnings-counter" style="text-align: center; font-size: 18px; margin-top: 5px;">
-                Earnings per Second: $<span id="earnings-per-second">0.00</span>
+                Earnings per Second: $<span id="earnings-per-second">0</span>
             </div>
             
             

--- a/public/modules/ui.js
+++ b/public/modules/ui.js
@@ -231,12 +231,17 @@ export function updateUI(balance, rent = 0, turns = 0, maxTurns = 0, currentBet 
     const bettingStatus = document.getElementById('betting-status');
     const rentStatus = document.getElementById('rent-status');
 
+    const safeBalance = Math.max(0, Math.round(Number(balance) || 0));
+    const safeBet = Math.max(0, Math.round(Number(currentBet) || 0));
+    const safeRent = Math.max(0, Math.round(Number(rent) || 0));
+    const rollsRemaining = Math.max(0, Math.round(Number(maxTurns) - Number(turns)));
+
     if (bettingStatus) {
-        bettingStatus.textContent = `Balance: $${balance.toLocaleString()} | Bet: $${currentBet}`;
+        bettingStatus.textContent = `Balance: $${safeBalance.toLocaleString()} | Bet: $${safeBet.toLocaleString()}`;
     }
 
     if (rentStatus) {
-        rentStatus.textContent = `Rent Due: $${rent.toLocaleString()} in ${maxTurns - turns} rolls`;
+        rentStatus.textContent = `Rent Due: $${safeRent.toLocaleString()} in ${rollsRemaining} rolls`;
     }
 }
 
@@ -274,8 +279,9 @@ export function flashScreen(color) {
  * Displays a winning amount on the screen with an animation.
  */
 export function showWinningAmount(amount) {
+    const safeAmount = Math.max(0, Math.round(Number(amount) || 0));
     const winAmountDiv = document.createElement('div');
-    winAmountDiv.textContent = `+$${amount.toLocaleString()}`;
+    winAmountDiv.textContent = `+$${safeAmount.toLocaleString()}`;
     winAmountDiv.style.position = 'absolute';
     winAmountDiv.style.top = '50%';
     winAmountDiv.style.left = '50%';
@@ -303,8 +309,9 @@ export function showWinningAmount(amount) {
  * Displays a losing amount on the screen with an animation.
  */
 export function showLosingAmount(amount) {
+    const safeAmount = Math.max(0, Math.round(Number(amount) || 0));
     const loseAmountDiv = document.createElement('div');
-    loseAmountDiv.textContent = `-$${amount.toLocaleString()}`;
+    loseAmountDiv.textContent = `-$${safeAmount.toLocaleString()}`;
     loseAmountDiv.style.position = 'absolute';
     loseAmountDiv.style.top = '50%';
     loseAmountDiv.style.left = '50%';
@@ -406,7 +413,7 @@ export function showItemPopup(configOrBalance, maybeItems, maybePurchasedItems) 
         .sort(() => Math.random() - 0.5)
         .slice(0, 3);
 
-    popup.style.display = 'block';
+    popup.style.display = 'flex';
     itemList.innerHTML = '';
 
     const restockFeeElement = document.getElementById('restock-fee');
@@ -621,12 +628,18 @@ export function addItemToPurchasedItems(item, purchasedItems = []) {
 export function updatePurchasedItemsDisplay(items = []) {
     const purchasedItemsDisplay = document.getElementById('purchased-items-display');
 
-    if (!Array.isArray(items)) {
-        console.error('updatePurchasedItemsDisplay received an invalid items array.');
+    if (!purchasedItemsDisplay) {
+        console.error('Purchased items display container not found.');
         return;
     }
 
-    // Array of hover sound file paths
+    if (!Array.isArray(items)) {
+        console.error('updatePurchasedItemsDisplay received an invalid items array.');
+        items = [];
+    }
+
+    purchasedItemsDisplay.innerHTML = '';
+
     const hoverSounds = [
         '/sounds/itemHover0.ogg',
         '/sounds/itemHover1.ogg',
@@ -636,45 +649,68 @@ export function updatePurchasedItemsDisplay(items = []) {
         '/sounds/itemHover5.ogg',
     ];
 
-    items.forEach(item => {
-        // Check if the item is already displayed
-        const existingItem = Array.from(purchasedItemsDisplay.children).find(child => 
-            child.getAttribute('data-item-name') === item.name
-        );
-
-        if (!existingItem) {
-            const itemContainer = document.createElement('div');
-            itemContainer.classList.add('purchased-item');
-            itemContainer.setAttribute('data-item-name', item.name); // Add name as data-attribute
-            itemContainer.setAttribute('data-item-description', item.description || 'No description available.'); // Add description as data-attribute
-
-            // Add item image
-            const itemImage = document.createElement('img');
-            const itemNameFormatted = item.name.replace(/\s/g, '').replace(/[^a-zA-Z0-9]/g, '');
-            itemImage.src = `/images/itemimage/${itemNameFormatted}.png`;
-            itemImage.alt = item.name;
-            itemImage.onerror = () => { itemImage.src = '/images/itemimage/Item_NoIcon.png'; };
-            itemImage.classList.add('item-image');
-
-            // Add hover event to play a random sound
-            itemContainer.addEventListener('mouseenter', () => {
-                const randomSound = hoverSounds[Math.floor(Math.random() * hoverSounds.length)];
-                const audio = new Audio(randomSound);
-                audio.play().catch(err => console.error('Error playing hover sound:', err));
-            });
-
-            // Add item label
-            const itemLabel = document.createElement('span');
-            itemLabel.textContent = item.name;
-
-            itemContainer.appendChild(itemImage);
-            itemContainer.appendChild(itemLabel);
-
-            purchasedItemsDisplay.appendChild(itemContainer);
+    const itemMap = new Map();
+    items.forEach((item) => {
+        if (!item || !item.name) {
+            return;
         }
+
+        if (!itemMap.has(item.name)) {
+            itemMap.set(item.name, { ...item, count: 0 });
+        }
+        const entry = itemMap.get(item.name);
+        entry.count += 1;
     });
 
-    console.log('Purchased Items Display Updated:', items);
+    const totalItems = items.length;
+    const scale = Math.max(0.55, 1 - Math.max(0, totalItems - 6) * 0.05);
+    purchasedItemsDisplay.style.setProperty('--purchased-item-scale', scale.toFixed(2));
+    purchasedItemsDisplay.dataset.totalItems = String(totalItems);
+
+    itemMap.forEach((itemData) => {
+        const itemContainer = document.createElement('div');
+        itemContainer.classList.add('purchased-item', 'purchased-item--animate-in');
+        itemContainer.setAttribute('data-item-name', itemData.name);
+        itemContainer.setAttribute('data-item-description', itemData.description || 'No description available.');
+
+        const itemImage = document.createElement('img');
+        const itemNameFormatted = itemData.name.replace(/\s/g, '').replace(/[^a-zA-Z0-9]/g, '');
+        itemImage.src = `/images/itemimage/${itemNameFormatted}.png`;
+        itemImage.alt = itemData.name;
+        itemImage.onerror = () => { itemImage.src = '/images/itemimage/Item_NoIcon.png'; };
+        itemImage.classList.add('item-image');
+
+        const itemLabel = document.createElement('span');
+        itemLabel.classList.add('purchased-item__label');
+        itemLabel.textContent = itemData.name;
+
+        const countBadge = document.createElement('span');
+        countBadge.classList.add('purchased-item__count');
+        countBadge.textContent = `x${itemData.count}`;
+        if (itemData.count <= 1) {
+            countBadge.classList.add('purchased-item__count--hidden');
+        }
+
+        itemContainer.appendChild(itemImage);
+        itemContainer.appendChild(itemLabel);
+        itemContainer.appendChild(countBadge);
+
+        itemContainer.addEventListener('mouseenter', () => {
+            const randomSound = hoverSounds[Math.floor(Math.random() * hoverSounds.length)];
+            const audio = new Audio(randomSound);
+            audio.play().catch(err => console.error('Error playing hover sound:', err));
+        });
+
+        purchasedItemsDisplay.appendChild(itemContainer);
+
+        requestAnimationFrame(() => {
+            itemContainer.classList.add('purchased-item--animate-ready');
+            setTimeout(() => {
+                itemContainer.classList.remove('purchased-item--animate-in', 'purchased-item--animate-ready');
+            }, 400);
+        });
+    });
+
 }
 
 
@@ -683,8 +719,9 @@ export function updatePurchasedItemsDisplay(items = []) {
  * Displays a bonus earned from purchased item effects.
  */
 export function displayBonusFromItems(bonus) {
+    const safeBonus = Math.round(Number(bonus) || 0);
     const bonusElement = document.createElement('div');
-    bonusElement.textContent = `Bonus: $${bonus.toLocaleString()}`;
+    bonusElement.textContent = `Bonus: $${safeBonus.toLocaleString()}`;
     bonusElement.style.position = 'absolute';
     bonusElement.style.top = '50%';
     bonusElement.style.left = '50%';
@@ -754,7 +791,8 @@ export function updateBalanceDisplay(balance) {
     balanceDisplay.appendChild(dollarSignImage);
 
     // Convert the balance to a string and iterate over each digit
-    const balanceString = balance.toString();
+    const safeBalance = Math.max(0, Math.round(Number(balance) || 0));
+    const balanceString = safeBalance.toString();
     for (const digit of balanceString) {
         // Create an image element for each digit
         const digitImage = document.createElement('img');
@@ -1407,21 +1445,24 @@ let currentEarningsValue = 0; // Current earnings per second
 function animateEarningsCounter(target, currentValue) {
     const earningsCounterElement = document.getElementById("earnings-per-second");
     if (!earningsCounterElement) {
-        // Skip execution if the element is not found
         return;
     }
 
-    const step = (target - currentValue) / 20; // Animation duration divided into steps
-    let animationFrame = 0;
+    const startValue = Math.max(0, Math.round(Number(currentValue) || 0));
+    const endValue = Math.max(0, Math.round(Number(target) || 0));
+    const totalFrames = 16;
+    let frame = 0;
 
     const updateAnimation = () => {
-        if (animationFrame < 20) {
-            currentValue += step;
-            earningsCounterElement.textContent = currentValue.toFixed(2);
-            animationFrame++;
+        if (frame < totalFrames) {
+            const progress = frame / totalFrames;
+            const interpolated = Math.round(startValue + (endValue - startValue) * progress);
+            earningsCounterElement.textContent = interpolated.toLocaleString();
+            frame++;
             requestAnimationFrame(updateAnimation);
         } else {
-            earningsCounterElement.textContent = target.toFixed(2); // Final value
+            earningsCounterElement.textContent = endValue.toLocaleString();
+            earningsCounterElement.dataset.currentValue = String(endValue);
         }
     };
 
@@ -1436,13 +1477,29 @@ export function setEarningsPerSecond(value) {
         console.warn("Earnings counter element not found. Skipping setEarningsPerSecond.");
         return;
     }
-    animateEarningsCounter(value, parseFloat(earningsCounterElement.textContent) || 0);
+
+    const sanitizedTarget = Math.max(0, Math.round(Number(value) || 0));
+    const storedValue = Number(earningsCounterElement.dataset.currentValue);
+    const currentValue = Number.isFinite(storedValue)
+        ? storedValue
+        : Math.max(0, Math.round(Number(earningsCounterElement.textContent.replace(/[^0-9-]/g, '')) || 0));
+
+    animateEarningsCounter(sanitizedTarget, currentValue);
+
+    earningsCounterElement.dataset.currentValue = String(sanitizedTarget);
+    earningsPerSecond = sanitizedTarget;
+    currentEarningsValue = sanitizedTarget;
 }
 
 // Start a live update interval
 setInterval(() => {
-    currentEarningsValue += earningsPerSecond;
-    animateEarningsCounter(currentEarningsValue, currentEarningsValue - earningsPerSecond); // Update incrementally
+    if (earningsPerSecond <= 0) {
+        return;
+    }
+
+    const previousValue = currentEarningsValue;
+    currentEarningsValue = Math.max(0, Math.round(currentEarningsValue + earningsPerSecond));
+    animateEarningsCounter(currentEarningsValue, previousValue);
 }, 1000);
 
 function calculateEarningsPerSecond(currentBalance) {

--- a/public/style.css
+++ b/public/style.css
@@ -66,14 +66,15 @@ body {
 
 /* Game Container Styling */
 #game-container {
-    background-color: rgba(0, 0, 0, 0.8);
-    border-radius: 10px;
-    box-shadow: 0 4px 6px rgba(255, 255, 255, 0.2);
-    width: 93%;
-    max-width: 5000px;
-    padding: 10px;
+    background-color: rgba(0, 0, 0, 0.82);
+    border-radius: 16px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+    width: min(92vw, 1600px);
+    margin: 0 auto;
+    padding: 18px 24px;
     text-align: center;
     color: white;
+    gap: 24px;
 }
 
 /* Button Styles */
@@ -541,21 +542,26 @@ h1 {
 /* Game Container Layout */
 #game-container {
     display: flex;
-    height: 100vh;
+    align-items: stretch;
+    height: min(100vh, 920px);
 }
 
 /* Left Side (Store, Hustler Info, Inventory) */
 #left-side {
-    flex: 0.8;
+    flex: 0 0 360px;
+    max-width: 380px;
+    width: 100%;
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    align-items: center;
-    background: url('/images/Backfrounf_Moving_0.gif') center center no-repeat; /* Add background image */
-    background-size: cover; /* Ensures the image covers the container completely */
-    padding: 10px;
+    align-items: stretch;
+    gap: 18px;
+    background: url('/images/Backfrounf_Moving_0.gif') center center no-repeat;
+    background-size: cover;
+    padding: 16px 18px;
     color: white;
     overflow-y: auto;
+    border-radius: 12px;
 }
 
 #roll-ticker {
@@ -698,6 +704,13 @@ h1 {
 }
 
 #buy-item-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    width: 100%;
+    max-width: 340px;
+    margin: 0 auto;
     text-align: center;
 }
 
@@ -711,22 +724,24 @@ h1 {
 
 /* Right Side (Gameplay) */
 #right-side {
-    flex: 2;
+    flex: 1 1 auto;
+    min-width: 0;
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
     align-items: center;
     background-color: #11111100;
     color: white;
-    padding: 15px;
+    padding: 24px 18px;
     overflow-y: auto;
+    gap: 18px;
 }
 
 #dice-container {
-    margin-top: -400px;
+    margin: 0;
     display: flex;
     justify-content: center;
-    gap: 10px;
+    gap: 18px;
 }
 
 .button-image {
@@ -736,7 +751,12 @@ h1 {
 }
 
 #controls {
-    margin-top: 400px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 8px;
+    width: 100%;
 }
 
 #gameStatus {
@@ -868,50 +888,64 @@ h1 {
 /* Buy Item Container Styling */
 #buy-item-container {
     display: none;
-    position: absolute; /* Use absolute to position it under the store sign */
-    top: calc(25% + 10px); /* Position it 10px below the store image */
-    left: 10;
-    width: 25.5%; /* Set the desired width */
-    height: auto; /* Adjust height based on content */
-    background: url('/images/Border_BuyAnItem.gif') center center no-repeat; /* Add background image */
-    background-size: 100% 100%; /* Stretch image to fully fill the container */
-    border: 1px solid #FFD700;
-    border-radius: 12px;
-    z-index: 100; /* Ensure it's on top of other elements */
-    box-shadow: 0 12px 6px rgba(255, 255, 255, 0.2);
+    position: relative;
+    width: 100%;
+    max-width: 320px;
+    margin: 0 auto;
+    padding: 32px 20px 28px;
+    background: url('/images/Border_BuyAnItem.gif') center center / 100% 100% no-repeat;
+    border: 1px solid rgba(255, 215, 0, 0.4);
+    border-radius: 18px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
     text-align: center;
     color: white;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
 }
 
 /* Item List Buttons */
+#item-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+    max-height: 220px;
+    overflow-y: auto;
+    padding: 0 12px;
+}
+
 #item-list button {
-    width: 80%;
+    width: 100%;
     background-color: #28a745;
-    margin: 12px 0;
-    font-size: 12px;
+    margin: 0;
+    font-size: 14px;
     border: none;
-    border-radius: 5px;
+    border-radius: 999px;
     color: white;
     cursor: pointer;
-    transition: background-color 0.3s ease;
+    padding: 10px 16px;
+    transition: background-color 0.3s ease, transform 0.2s ease;
 }
 
 #item-list button:hover {
     background-color: #218838;
+    transform: translateY(-2px);
 }
 
 /* Item Description Styling */
 #item-description {
     display: none; /* Initially hidden */
-    background: rgba(0, 0, 0, 0.8);
+    background: rgba(0, 0, 0, 0.72);
     color: #fff;
-    padding: 10px;
-    border: 1px solid #FFD700;
-    border-radius: 5px;
-    margin-top: 10px;
+    padding: 12px 16px;
+    border: 1px solid rgba(255, 215, 0, 0.35);
+    border-radius: 12px;
+    margin: 8px auto 0;
     font-size: 14px;
     text-align: center;
-    box-shadow: 0 4px 6px rgba(255, 255, 255, 0.2);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+    width: calc(100% - 32px);
 }
 
 
@@ -923,13 +957,17 @@ h1 {
     font-size: 16px;
 }
 #purchased-items-section {
-    margin-top: 20px;
-    background-color: rgba(0, 0, 0, 0.8);
-    border: 1px solid #FFD700;
-    border-radius: 10px;
-    padding: 10px;
+    margin: 0;
+    background-color: rgba(0, 0, 0, 0.55);
+    border: 1px solid rgba(255, 215, 0, 0.35);
+    border-radius: 14px;
+    padding: 14px 12px;
     color: white;
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
 }
 
 .items-grid {
@@ -973,42 +1011,97 @@ h1 {
 }
 
 #purchased-items-display {
-    display: flex;
-    flex-wrap: wrap; /* Allow wrapping */
-    gap: 10px; /* Spacing between items */
-    justify-content: center;
-    align-items: center;
+    --purchased-item-scale: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+    gap: 12px;
+    justify-items: center;
+    align-items: stretch;
+    padding: 4px;
+    max-height: 240px;
+    overflow-y: auto;
 }
 
 .purchased-item {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 10px;
+    gap: 6px;
+    padding: 10px 8px;
     text-align: center;
+    background: rgba(8, 8, 8, 0.55);
+    border: 1px solid rgba(255, 215, 0, 0.25);
+    border-radius: 12px;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+    transform: scale(var(--purchased-item-scale));
+    transition: transform 0.3s ease, border-color 0.3s ease, background 0.3s ease, opacity 0.3s ease;
+    opacity: 1;
 }
 
-.purchased-item img {
-    width: 50px; /* Size adjustments */
-    height: 50px;
+.purchased-item .item-image {
+    width: 54px;
+    height: 54px;
     object-fit: contain;
-    margin-bottom: 5px;
     border-radius: 8px;
+    filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.4));
+}
+
+.purchased-item__label {
+    font-size: 12px;
+    line-height: 1.2;
+    max-width: 120px;
+}
+
+.purchased-item__count {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: rgba(255, 215, 0, 0.9);
+    color: #2b1a00;
+    font-size: 11px;
+    font-weight: 700;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+}
+
+.purchased-item__count--hidden {
+    display: none;
+}
+
+.purchased-item--animate-in {
+    opacity: 0;
+    transform: scale(calc(var(--purchased-item-scale) * 0.6));
+}
+
+.purchased-item--animate-in.purchased-item--animate-ready {
+    opacity: 1;
+    transform: scale(var(--purchased-item-scale));
+}
+
+.purchased-item:hover {
+    border-color: rgba(255, 215, 0, 0.65);
+    background: rgba(18, 18, 18, 0.75);
+    transform: scale(calc(var(--purchased-item-scale) * 1.05));
 }
 
 .purchased-item:hover::after {
-    content: attr(data-description);
+    content: attr(data-item-description);
     position: absolute;
-    top: -40px; /* Position above the emoji */
+    bottom: calc(100% + 8px);
     left: 50%;
     transform: translateX(-50%);
-    padding: 5px;
-    background: #222;
-    color: white;
-    border-radius: 5px;
-    white-space: break-spaces;
-    font-size: 14px;
-    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.5);
+    padding: 8px 10px;
+    background: rgba(12, 12, 12, 0.92);
+    color: #fff;
+    border-radius: 8px;
+    white-space: normal;
+    font-size: 12px;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+    width: 180px;
+    pointer-events: none;
+    z-index: 10;
 }
 #leaderboard-overlay {
     position: fixed;
@@ -1062,9 +1155,12 @@ h1 {
 /* Flex container for the Done Shopping and Restock buttons */
 #button-container {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
-    margin-top: 20px;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 16px;
+    width: 100%;
 }
 
 /* Restock Button Styling */
@@ -1081,8 +1177,9 @@ h1 {
     justify-content: center; /* Center content horizontally */
     gap: 8px; /* Space between icon and text */
     transition: background-color 0.3s ease, transform 0.2s ease;
-    width: 180px; /* Set a fixed width to maintain consistency */
-    max-width: 100%; /* Prevent it from overflowing the container */
+    min-width: 0;
+    width: auto;
+    max-width: 100%;
 }
 
 /* Hover and Active States */
@@ -1760,9 +1857,9 @@ body {
     justify-content: center;
     align-items: center;
     gap: 0;
-    background: rgba(0, 0, 0, 0.92);
+    background: rgba(0, 0, 0, 0.9);
     z-index: 9999;
-    padding: 32px;
+    padding: 0;
     box-sizing: border-box;
     overflow: hidden;
 }
@@ -1907,24 +2004,6 @@ body {
     border-radius: 8px; /* Rounded corners for a polished look */
 }
 
-/* Purchased Items Display */
-.purchased-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin: 10px;
-    text-align: center;
-}
-
-/* Purchased Item Images */
-.purchased-item img {
-    width: 50px; /* Smaller size for inventory */
-    height: 50px;
-    object-fit: contain; /* Ensure images fit */
-    margin-bottom: 5px;
-    border-radius: 8px;
-}
-
 /* General Button Styling for Item Buttons */
 .item-button {
     width: 100%;
@@ -1990,43 +2069,6 @@ body {
     max-width: 200px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
-/* Purchased Item Container Styling */
-.purchased-item {
-    width: 50px; /* Adjust width of the item container */
-    height: 50px; /* Adjust height of the item container */
-    margin: 10px; /* Spacing between items */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative; /* Allows precise control over child elements */
-}
-
-/* Hide Item Label Below Icons */
-.purchased-item span {
-    display: none; /* Hide the item name label */
-}
-
-/* Item Image Styling */
-.purchased-item .item-image {
-    width: 65px; /* Set the desired width for the image */
-    height: auto; /* Maintain aspect ratio */
-}
-.purchased-item:hover::after {
-    content: attr(data-item-name) '\A' attr(data-item-description); /* Use name and description */
-    position: absolute;
-    bottom: -40px; /* Adjust for extra space for the description */
-    background-color: rgba(0, 0, 0, 0.9);
-    color: white;
-    padding: 10px;
-    border-radius: 5px;
-    font-size: 12px;
-    text-align: center;
-    white-space: pre-line; /* Ensures line breaks from \A */
-    z-index: 10;
-    width: 250px; /* Adjust tooltip width */
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.8); /* Add subtle shadow for better visibility */
-}
-
 /* Bet 25 Button */
 img[src="/images/Button_Bet25.gif"]:hover {
     content: url('/images/Button_Bet25_Hover.gif');


### PR DESCRIPTION
## Summary
- tighten game economy updates so all balance adjustments and displays round to whole dollars
- streamline the roll sequence so only the post-animation dice audio plays and remove the filler shake clip
- refactor the shop and purchased-item UI to a compact, responsive grid with scaling badges and animate-in effects, and stretch the game-over overlay to fill the viewport

## Testing
- npm install *(fails: 403 Forbidden - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d983dfa4c0832d941916ffc88aface